### PR TITLE
Upgrade to terraform-plugin-go v0.3.0

### DIFF
--- a/asgotypes/primitive.go
+++ b/asgotypes/primitive.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"reflect"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // GoPrimitive is a way to get at the contents of a tftypes.Value without
@@ -45,7 +45,7 @@ func (dt *GoPrimitive) FromTerraform5Value(value tftypes.Value) error {
 		return nil
 	}
 	switch {
-	case value.Is(tftypes.String):
+	case value.Type().Is(tftypes.String):
 		var str string
 		err := value.As(&str)
 		if err != nil {
@@ -53,7 +53,7 @@ func (dt *GoPrimitive) FromTerraform5Value(value tftypes.Value) error {
 		}
 		dt.Value = str
 		return nil
-	case value.Is(tftypes.Number):
+	case value.Type().Is(tftypes.Number):
 		num := big.NewFloat(-42)
 		err := value.As(&num)
 		if err != nil {
@@ -61,7 +61,7 @@ func (dt *GoPrimitive) FromTerraform5Value(value tftypes.Value) error {
 		}
 		dt.Value = num
 		return nil
-	case value.Is(tftypes.Bool):
+	case value.Type().Is(tftypes.Bool):
 		var b bool
 		err := value.As(&b)
 		if err != nil {
@@ -69,7 +69,7 @@ func (dt *GoPrimitive) FromTerraform5Value(value tftypes.Value) error {
 		}
 		dt.Value = b
 		return nil
-	case value.Is(tftypes.Object{}):
+	case value.Type().Is(tftypes.Object{}):
 		msv := map[string]tftypes.Value{}
 		err := value.As(&msv)
 		if err != nil {
@@ -86,7 +86,7 @@ func (dt *GoPrimitive) FromTerraform5Value(value tftypes.Value) error {
 		}
 		dt.Value = res
 		return nil
-	case value.Is(tftypes.Tuple{}):
+	case value.Type().Is(tftypes.Tuple{}):
 		vals := []tftypes.Value{}
 		err := value.As(&vals)
 		if err != nil {
@@ -103,7 +103,7 @@ func (dt *GoPrimitive) FromTerraform5Value(value tftypes.Value) error {
 		}
 		dt.Value = res
 		return nil
-	case value.Is(tftypes.List{}) || value.Is(tftypes.Set{}):
+	case value.Type().Is(tftypes.List{}) || value.Type().Is(tftypes.Set{}):
 		vals := []tftypes.Value{}
 		err := value.As(&vals)
 		if err != nil {
@@ -130,7 +130,7 @@ func (dt *GoPrimitive) FromTerraform5Value(value tftypes.Value) error {
 		}
 		dt.Value = res.Interface()
 		return nil
-	case value.Is(tftypes.Map{}):
+	case value.Type().Is(tftypes.Map{}):
 		msv := map[string]tftypes.Value{}
 		err := value.As(&msv)
 		if err != nil {

--- a/asgotypes/primitive_test.go
+++ b/asgotypes/primitive_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 func TestGoPrimitive(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.15
 
 require (
 	github.com/google/go-cmp v0.5.4
-	github.com/hashicorp/terraform-plugin-go v0.2.0
+	github.com/hashicorp/terraform-plugin-go v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -26,14 +26,13 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-plugin v1.3.0/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYtXdgmf1AVNs0=
-github.com/hashicorp/terraform-plugin-go v0.2.0 h1:zV9OdhCKKXem+LdNi7Vt2Znz6oeED2rI0jmfRDcWLc0=
-github.com/hashicorp/terraform-plugin-go v0.2.0/go.mod h1:10V6F3taeDWVAoLlkmArKttR3IULlRWFAGtQIQTIDr4=
+github.com/hashicorp/terraform-plugin-go v0.3.0 h1:AJqYzP52JFYl9NABRI7smXI1pNjgR5Q/y2WyVJ/BOZA=
+github.com/hashicorp/terraform-plugin-go v0.3.0/go.mod h1:dFHsQMaTLpON2gWhVWT96fvtlc/MF1vSy3OdMhWBzdM=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=


### PR DESCRIPTION
Upgrade to terraform-plugin-go v0.3.0 and fix compilation errors due to
breaking changes. We should still, as documented in #5, do some work
here on asgotypes, I think, but this lets us build things with 0.3.0 in
parallel to that work.